### PR TITLE
Add support for updating version ranges in properties.

### DIFF
--- a/src/it/properties/pom.xml
+++ b/src/it/properties/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2012 RedEngine Ltd, http://www.redengine.co.nz. All rights reserved. -->
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.stickycode.plugins.it</groupId>
+	<artifactId>sticky-bounds-plugin-reflector</artifactId>
+	<version>1.1-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+  <properties>
+  	<sticky-coercion.version>[2.1,3)</sticky-coercion.version>
+  </properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>net.stickycode</groupId>
+			<artifactId>sticky-coercion</artifactId>
+			<version>${sticky-coercion.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>net.stickycode.plugins</groupId>
+				<artifactId>bounds-maven-plugin</artifactId>
+				<version>@pom.version@</version>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<goals>
+							<goal>update</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+		</plugins>
+	</build>
+</project>

--- a/src/it/properties/verify.bsh
+++ b/src/it/properties/verify.bsh
@@ -1,0 +1,18 @@
+import java.io.*;
+import java.util.*;
+
+import org.codehaus.plexus.util.*;
+
+File pomFile = new File( basedir, "pom.xml" );
+System.out.println( "Checking for existence of first test file: " + pomFile );
+if (!pomFile.exists())
+  throw new RuntimeException(pomFile.toString() + " not found" );
+
+
+String pom = FileUtils.fileRead( pomFile, "UTF-8" ).trim();
+
+if (pom.contains(">[2.7,3)<"))
+	return true;
+	
+System.err.println("Expected version to be [2.7,3)");
+return false;

--- a/src/test/java/net/stickycode/plugin/bounds/StickyBoundsMojoIntegrationTest.java
+++ b/src/test/java/net/stickycode/plugin/bounds/StickyBoundsMojoIntegrationTest.java
@@ -50,7 +50,7 @@ public class StickyBoundsMojoIntegrationTest {
         "",
         "[3.1,4)");
 
-    new StickyBoundsMojo().update(pom, artifact, "[3.6,4)");
+    new StickyBoundsMojo().updateDependency(pom, artifact, "[3.6,4)");
     XPathContext context = new XPathContext("mvn", "http://maven.apache.org/POM/4.0.0");
 
     Nodes versions = pom.query("//mvn:version", context);
@@ -72,7 +72,7 @@ public class StickyBoundsMojoIntegrationTest {
         "",
         "[2.1,4)");
     
-    new StickyBoundsMojo().update(pom, artifact, "[2.6,3)");
+    new StickyBoundsMojo().updateDependency(pom, artifact, "[2.6,3)");
     XPathContext context = new XPathContext("mvn", "http://maven.apache.org/POM/4.0.0");
     
     Nodes versions = pom.query("//mvn:version", context);
@@ -94,7 +94,7 @@ public class StickyBoundsMojoIntegrationTest {
         "test-jar",
         "[2.1,4)");
 
-    new StickyBoundsMojo().update(pom, artifact, "[2.6,3)");
+    new StickyBoundsMojo().updateDependency(pom, artifact, "[2.6,3)");
     XPathContext context = new XPathContext("mvn", "http://maven.apache.org/POM/4.0.0");
 
     Nodes versions = pom.query("//mvn:version", context);


### PR DESCRIPTION
We have some projects that make use of defining version ranges inside properties that currently get skipped by the bounds plugin.

This PR adds support for updating properties named `${artifactName.version}` ( which happens to be the default name that IntelliJ IDEA gives a version when you extract it ).

This PR also introduces a new property `updateProperties` which defaults to `false`, currently any dependencies that use properties get the property reference replaces with the new bounds, which is somewhat unexpected behaviour.

This PR also checks and updates the `<dependencyManagement>` section if declared.
